### PR TITLE
Autodetect spec files as yaml and monit files as monitrc

### DIFF
--- a/ftdetect/bosh.vim
+++ b/ftdetect/bosh.vim
@@ -3,6 +3,9 @@
 " Author:   Luan Santos <vim@luan.sh>
 " URL:      https://github.com/luan/vim-bosh
 
+autocmd BufNewFile,BufRead monit set filetype=monitrc
+autocmd BufNewFile,BufRead spec set filetype=yaml
+
 autocmd BufNewFile,BufRead *.yml,*.yaml  call s:SelectBosh()
 
 fun! s:SelectBosh()


### PR DESCRIPTION
Added filetype autodetection for `spec` ( as `yaml`) and `monit` (as `monitrc`)

The `monitrc` filetype requires https://github.com/tmatilai/vim-monit.